### PR TITLE
feature: apply source action edits

### DIFF
--- a/packages/source-action-worker/src/parts/Change/Change.ts
+++ b/packages/source-action-worker/src/parts/Change/Change.ts
@@ -1,17 +1,5 @@
-export interface Range {
-  readonly columnIndex: number
-  readonly rowIndex: number
-}
-
-export interface Selection {
-  readonly end: Range
-  readonly start: Range
-}
-
 export interface Change {
-  readonly deleted: readonly string[]
-  readonly end: Range
-  readonly inserted: readonly string[]
-  readonly origin: string
-  readonly start: Range
+  readonly endOffset: number
+  readonly inserted: string
+  readonly startOffset: number
 }

--- a/packages/source-action-worker/src/parts/SelectItem/SelectItem.ts
+++ b/packages/source-action-worker/src/parts/SelectItem/SelectItem.ts
@@ -5,8 +5,11 @@ import * as GetEdits from '../GetEdits/GetEdits.ts'
 import * as SourceActionName from '../SourceActionName/SourceActionName.ts'
 
 export const selectItem = async (state: SourceActionState, name: string): Promise<SourceActionState> => {
-  const { editorUid } = state
-  if (name === SourceActionName.OrganizeImports) {
+  const { editorUid, items } = state
+  const item = items.find((item) => item.name === name)
+  if (item?.edits) {
+    await ApplyEdit.applyEdit(editorUid, item.edits)
+  } else if (name === SourceActionName.OrganizeImports) {
     const edits = await GetEdits.getEdits(editorUid)
     await ApplyEdit.applyEdit(editorUid, edits)
   }

--- a/packages/source-action-worker/src/parts/SourceActionItem/SourceActionItem.ts
+++ b/packages/source-action-worker/src/parts/SourceActionItem/SourceActionItem.ts
@@ -1,4 +1,7 @@
+import type { Change } from '../Change/Change.ts'
+
 export interface SourceActionItem {
+  readonly edits?: readonly Change[]
   readonly isFocused: boolean
   readonly name: string
 }

--- a/packages/source-action-worker/test/SelectItem.test.ts
+++ b/packages/source-action-worker/test/SelectItem.test.ts
@@ -1,0 +1,101 @@
+import { expect, jest, test } from '@jest/globals'
+import { MockRpc } from '@lvce-editor/rpc'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { set as setEditorWorker } from '../src/parts/EditorWorker/EditorWorker.ts'
+import { set as setExtensionHostWorker } from '../src/parts/ExtensionHostWorker/ExtensionHostWorker.ts'
+import { selectItem } from '../src/parts/SelectItem/SelectItem.ts'
+import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.ts'
+import * as WidgetId from '../src/parts/WidgetId/WidgetId.ts'
+
+test('selectItem applies edits from the selected code action', async () => {
+  const editorInvoke = jest.fn()
+  setEditorWorker(
+    MockRpc.create({
+      commandMap: {},
+      invoke: editorInvoke,
+    }),
+  )
+  setExtensionHostWorker(
+    MockRpc.create({
+      commandMap: {},
+      invoke() {
+        throw new Error('unexpected extension host invocation')
+      },
+    }),
+  )
+  const edits = [
+    {
+      endOffset: 28,
+      inserted: 'abort',
+      startOffset: 23,
+    },
+  ]
+  const state = {
+    ...createDefaultState(),
+    editorUid: 42,
+    items: [
+      {
+        edits,
+        isFocused: true,
+        name: "Change spelling to 'abort'",
+      },
+    ],
+  }
+
+  await expect(selectItem(state, "Change spelling to 'abort'")).resolves.toBe(state)
+  expect(editorInvoke).toHaveBeenNthCalledWith(1, 'Editor.applyDocumentEdits', 42, edits)
+  expect(editorInvoke).toHaveBeenNthCalledWith(
+    2,
+    'Editor.closeWidget2',
+    42,
+    WidgetId.SourceAction,
+    'SourceActions',
+    WhenExpression.FocusSourceActions,
+  )
+})
+
+test('selectItem executes organize imports when the action has no edits', async () => {
+  const edits = [
+    {
+      endOffset: 1,
+      inserted: '',
+      startOffset: 0,
+    },
+  ]
+  const editorInvoke = jest.fn()
+  const extensionHostInvoke = jest.fn(() => edits)
+  setEditorWorker(
+    MockRpc.create({
+      commandMap: {},
+      invoke: editorInvoke,
+    }),
+  )
+  setExtensionHostWorker(
+    MockRpc.create({
+      commandMap: {},
+      invoke: extensionHostInvoke,
+    }),
+  )
+  const state = {
+    ...createDefaultState(),
+    editorUid: 42,
+    items: [
+      {
+        isFocused: true,
+        name: 'Organize Imports',
+      },
+    ],
+  }
+
+  await expect(selectItem(state, 'Organize Imports')).resolves.toBe(state)
+  expect(extensionHostInvoke).toHaveBeenCalledWith('ExtensionHostOrganizeImports.execute', 42)
+  expect(editorInvoke).toHaveBeenNthCalledWith(1, 'Editor.applyDocumentEdits', 42, edits)
+  expect(editorInvoke).toHaveBeenNthCalledWith(
+    2,
+    'Editor.closeWidget2',
+    42,
+    WidgetId.SourceAction,
+    'SourceActions',
+    WhenExpression.FocusSourceActions,
+  )
+})

--- a/packages/source-action-worker/test/SelectItem.test.ts
+++ b/packages/source-action-worker/test/SelectItem.test.ts
@@ -63,7 +63,8 @@ test('selectItem executes organize imports when the action has no edits', async 
     },
   ]
   const editorInvoke = jest.fn()
-  const extensionHostInvoke = jest.fn(() => edits)
+  const extensionHostInvoke = jest.fn<(...args: readonly unknown[]) => readonly unknown[]>()
+  extensionHostInvoke.mockReturnValue(edits)
   setEditorWorker(
     MockRpc.create({
       commandMap: {},


### PR DESCRIPTION
Applies edit-backed quick fixes selected from the source-actions widget while preserving organize imports.