### PR TITLE
feat: support dynamic source actions

### DIFF
--- a/packages/source-action-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/source-action-worker/src/parts/CommandMap/CommandMap.ts
@@ -3,6 +3,7 @@ import * as Close from '../Close/Close.ts'
 import * as Create from '../Create/Create.ts'
 import * as Diff2 from '../Diff2/Diff2.ts'
 import * as Dispose from '../Dispose/Dispose.ts'
+import * as FocusSourceAction from '../FocusSourceAction/FocusSourceAction.ts'
 import * as GetKeyBindings from '../GetKeyBindings/GetKeyBindings.ts'
 import * as HandleEditorDeleteLeft from '../HandleEditorDeleteLeft/HandleEditorDeleteLeft.ts'
 import * as HandleEditorType from '../HandleEditorType/HandleEditorType.ts'
@@ -10,6 +11,7 @@ import * as HandleWheel from '../HandleWheel/HandleWheel.ts'
 import * as Initialize from '../Initialize/Initialize.ts'
 import * as LoadContent from '../LoadContent/LoadContent.ts'
 import * as Render2 from '../Render2/Render2.ts'
+import * as SelectCurrent from '../SelectCurrent/SelectCurrent.ts'
 import * as SelectItem from '../SelectItem/SelectItem.ts'
 import * as WrapCommand from '../SourceActionStates/SourceActionStates.ts'
 
@@ -18,6 +20,10 @@ export const commandMap = {
   'SourceActions.create': Create.create,
   'SourceActions.diff2': Diff2.diff2,
   'SourceActions.dispose': Dispose.dispose,
+  'SourceActions.focusFirst': WrapCommand.wrapCommand(FocusSourceAction.focusFirst),
+  'SourceActions.focusLast': WrapCommand.wrapCommand(FocusSourceAction.focusLast),
+  'SourceActions.focusNext': WrapCommand.wrapCommand(FocusSourceAction.focusNext),
+  'SourceActions.focusPrevious': WrapCommand.wrapCommand(FocusSourceAction.focusPrevious),
   'SourceActions.getCommandIds': WrapCommand.getCommandIds,
   'SourceActions.getKeyBindings': GetKeyBindings.getKeyBindings,
   'SourceActions.handleEditorDeleteLeft': WrapCommand.wrapCommand(HandleEditorDeleteLeft.handleEditorDeleteLeft),
@@ -26,6 +32,7 @@ export const commandMap = {
   'SourceActions.initialize': Initialize.initialize,
   'SourceActions.loadContent': WrapCommand.wrapCommand(LoadContent.loadContent),
   'SourceActions.render2': Render2.render2,
+  'SourceActions.selectCurrent': WrapCommand.wrapCommand(SelectCurrent.selectCurrent),
   'SourceActions.selectItem': WrapCommand.wrapCommand(SelectItem.selectItem),
   'SourceActions.terminate': terminate,
 }

--- a/packages/source-action-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
+++ b/packages/source-action-worker/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
@@ -1,3 +1,4 @@
 export const HandleWheel = 'handleWheel'
 export const HandleClick = 'handleClick'
+export const HandleSourceActionClick = 'handleSourceActionClick'
 export const HandleFocusIn = 'handleFocusIn'

--- a/packages/source-action-worker/src/parts/FocusSourceAction/FocusSourceAction.ts
+++ b/packages/source-action-worker/src/parts/FocusSourceAction/FocusSourceAction.ts
@@ -1,0 +1,35 @@
+import type { SourceActionState } from '../SourceActionState/SourceActionState.ts'
+
+const withFocusedIndex = (state: SourceActionState, focusedIndex: number): SourceActionState => ({
+  ...state,
+  focused: true,
+  focusedIndex,
+})
+
+export const focusFirst = (state: SourceActionState): SourceActionState => {
+  const { items } = state
+  return withFocusedIndex(state, items.length === 0 ? -1 : 0)
+}
+
+export const focusLast = (state: SourceActionState): SourceActionState => {
+  const { items } = state
+  return withFocusedIndex(state, items.length - 1)
+}
+
+export const focusNext = (state: SourceActionState): SourceActionState => {
+  const { focusedIndex: oldFocusedIndex, items } = state
+  if (items.length === 0) {
+    return withFocusedIndex(state, -1)
+  }
+  const focusedIndex = Math.min(oldFocusedIndex + 1, items.length - 1)
+  return withFocusedIndex(state, focusedIndex)
+}
+
+export const focusPrevious = (state: SourceActionState): SourceActionState => {
+  const { focusedIndex: oldFocusedIndex, items } = state
+  if (items.length === 0) {
+    return withFocusedIndex(state, -1)
+  }
+  const focusedIndex = Math.max(oldFocusedIndex - 1, 0)
+  return withFocusedIndex(state, focusedIndex)
+}

--- a/packages/source-action-worker/src/parts/GetEventListeners/GetEventListeners.ts
+++ b/packages/source-action-worker/src/parts/GetEventListeners/GetEventListeners.ts
@@ -4,8 +4,12 @@ import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEven
 export const getEventListeners = (): readonly DomEventListener[] => {
   return [
     {
+      name: DomEventListenerFunctions.HandleSourceActionClick,
+      params: ['handleSourceActionClick', 'event.target.dataset.name'],
+    },
+    {
       name: DomEventListenerFunctions.HandleWheel,
-      params: ['EditorCompletion.handleWheel', 'event.deltaMode', 'event.deltaY'],
+      params: ['EditorSourceAction.handleWheel', 'event.deltaMode', 'event.deltaY'],
       passive: true,
     },
   ]

--- a/packages/source-action-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/source-action-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -1,10 +1,10 @@
-import { KeyCode, KeyModifier } from '@lvce-editor/virtual-dom-worker'
+import { KeyCode } from '@lvce-editor/virtual-dom-worker'
 import * as WhenExpression from '../WhenExpression/WhenExpression.ts'
 import * as WidgetId from '../WidgetId/WidgetId.ts'
 
 const getCommand = (shortId: string): any => {
   return {
-    args: ['Completions', `Completions.${shortId}`, 0, WidgetId.Completion],
+    args: ['SourceActions', `SourceActions.${shortId}`, 0, WidgetId.SourceAction],
     command: 'Editor.executeWidgetCommand',
   }
 }
@@ -14,37 +14,32 @@ export const getKeyBindings = (): readonly any[] => {
     {
       key: KeyCode.DownArrow,
       ...getCommand('focusNext'),
-      when: WhenExpression.FocusEditorCompletions,
+      when: WhenExpression.FocusSourceActions,
     },
     {
       key: KeyCode.UpArrow,
       ...getCommand('focusPrevious'),
-      when: WhenExpression.FocusEditorCompletions,
+      when: WhenExpression.FocusSourceActions,
     },
     {
       key: KeyCode.Enter,
       ...getCommand('selectCurrent'),
-      when: WhenExpression.FocusEditorCompletions,
+      when: WhenExpression.FocusSourceActions,
     },
     {
       key: KeyCode.End,
       ...getCommand('focusLast'),
-      when: WhenExpression.FocusEditorCompletions,
+      when: WhenExpression.FocusSourceActions,
     },
     {
       key: KeyCode.Home,
       ...getCommand('focusFirst'),
-      when: WhenExpression.FocusEditorCompletions,
-    },
-    {
-      key: KeyModifier.CtrlCmd | KeyCode.Space,
-      ...getCommand('toggleDetails'),
-      when: WhenExpression.FocusEditorCompletions,
+      when: WhenExpression.FocusSourceActions,
     },
     {
       key: KeyCode.Escape,
       ...getCommand('close'),
-      when: WhenExpression.FocusEditorCompletions,
+      when: WhenExpression.FocusSourceActions,
     },
   ]
 }

--- a/packages/source-action-worker/src/parts/GetSourceActionListItemVirtualDom/GetSourceActionListItemVirtualDom.ts
+++ b/packages/source-action-worker/src/parts/GetSourceActionListItemVirtualDom/GetSourceActionListItemVirtualDom.ts
@@ -1,6 +1,8 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
+import { AriaRoles } from '@lvce-editor/virtual-dom-worker'
 import type { SourceActionItem } from '../SourceActionItem/SourceActionItem.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
@@ -19,10 +21,14 @@ export const getSourceActionListItemVirtualDom = (sourceAction: SourceActionItem
     {
       childCount: 2,
       className: actionClassName,
+      'data-name': name,
+      onClick: DomEventListenerFunctions.HandleSourceActionClick,
+      role: AriaRoles.Option,
       type: VirtualDomElements.Div,
     },
     {
       className: MergeClassNames.mergeClassNames(ClassNames.SourceActionIcon, ClassNames.MaskIcon, ClassNames.MaskIconSymbolFile),
+      'data-name': name,
       type: VirtualDomElements.Div,
     },
     text(name),

--- a/packages/source-action-worker/src/parts/GetSourceActions/GetSourceActions.ts
+++ b/packages/source-action-worker/src/parts/GetSourceActions/GetSourceActions.ts
@@ -1,10 +1,26 @@
 import type { SourceActionItem } from '../SourceActionItem/SourceActionItem.ts'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
+import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.ts'
 
-// TODO ask extension host worker instead
 export const getEditorSourceActions = async (editorId: number): Promise<readonly SourceActionItem[]> => {
-  // @ts-ignore
-  const sourceActions = await EditorWorker.invoke('Editor.getSourceActions', editorId)
-  // @ts-ignore
-  return sourceActions
+  const [contributedActions, languageId, offset, text, uri] = await Promise.all([
+    EditorWorker.invoke('Editor.getSourceActions', editorId),
+    EditorWorker.invoke('Editor.getLanguageId', editorId),
+    EditorWorker.getOffsetAtCursor(editorId),
+    EditorWorker.invoke('Editor.getText', editorId),
+    EditorWorker.invoke('Editor.getUri', editorId),
+  ])
+  const textDocument = {
+    documentId: editorId,
+    languageId,
+    text,
+    uri,
+  }
+  const providedActions = await ExtensionManagementWorker.invoke('Extensions.executeCodeActionProviders', textDocument, offset)
+  if (!Array.isArray(contributedActions) || !Array.isArray(providedActions)) {
+    throw new TypeError('Code actions must be an array')
+  }
+  const names = new Set(providedActions.map((action) => action?.name))
+  const uniqueContributedActions = contributedActions.filter((action) => !names.has(action?.name))
+  return [...providedActions, ...uniqueContributedActions]
 }

--- a/packages/source-action-worker/src/parts/GetSourceActionsVirtualDom/GetSourceActionsVirtualDom.ts
+++ b/packages/source-action-worker/src/parts/GetSourceActionsVirtualDom/GetSourceActionsVirtualDom.ts
@@ -24,7 +24,7 @@ const sourceActionsNode: VirtualDomNode = {
   type: VirtualDomElements.Div,
 }
 
-export const getSourceActionsVirtualDom = (sourceActions: readonly SourceActionItem[]): readonly VirtualDomNode[] => {
+export const getSourceActionsVirtualDom = (sourceActions: readonly SourceActionItem[], focusedIndex = -1): readonly VirtualDomNode[] => {
   if (sourceActions.length === 0) {
     return GetEmptySourceActionsVirtualDom.getEmptySourceActionsVirtualDom()
   }
@@ -35,11 +35,15 @@ export const getSourceActionsVirtualDom = (sourceActions: readonly SourceActionI
     {
       childCount: sourceActions.length,
       className: ClassNames.EditorSourceActionsList,
-      onClick: DomEventListenerFunctions.HandleClick,
       role: AriaRoles.ListBox,
       type: VirtualDomElements.Div,
     },
-    ...sourceActions.flatMap(GetSourceActionListItemVirtualDom.getSourceActionListItemVirtualDom),
+    ...sourceActions.flatMap((sourceAction, index) =>
+      GetSourceActionListItemVirtualDom.getSourceActionListItemVirtualDom({
+        ...sourceAction,
+        isFocused: index === focusedIndex,
+      }),
+    ),
   ]
   return dom
 }

--- a/packages/source-action-worker/src/parts/RenderFocusContext/RenderFocusContext.ts
+++ b/packages/source-action-worker/src/parts/RenderFocusContext/RenderFocusContext.ts
@@ -2,5 +2,5 @@ import type { SourceActionState } from '../SourceActionState/SourceActionState.t
 import * as WhenExpression from '../WhenExpression/WhenExpression.ts'
 
 export const renderFocusContext = (oldState: SourceActionState, newState: SourceActionState): readonly any[] => {
-  return [/* method */ 'Viewlet.setFocusContext', WhenExpression.FocusEditorRename]
+  return [/* method */ 'Viewlet.setFocusContext', WhenExpression.FocusSourceActions]
 }

--- a/packages/source-action-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/source-action-worker/src/parts/RenderItems/RenderItems.ts
@@ -3,6 +3,6 @@ import type { SourceActionState } from '../SourceActionState/SourceActionState.t
 import { getSourceActionsVirtualDom } from '../GetSourceActionsVirtualDom/GetSourceActionsVirtualDom.ts'
 
 export const renderItems = (oldState: SourceActionState, newState: SourceActionState): readonly any[] => {
-  const dom: readonly VirtualDomNode[] = [...getSourceActionsVirtualDom(newState.items)]
+  const dom: readonly VirtualDomNode[] = [...getSourceActionsVirtualDom(newState.items, newState.focusedIndex)]
   return [/* method */ 'Viewlet.setDom2', newState.uid, dom]
 }

--- a/packages/source-action-worker/src/parts/SelectCurrent/SelectCurrent.ts
+++ b/packages/source-action-worker/src/parts/SelectCurrent/SelectCurrent.ts
@@ -1,0 +1,11 @@
+import type { SourceActionState } from '../SourceActionState/SourceActionState.ts'
+import * as SelectItem from '../SelectItem/SelectItem.ts'
+
+export const selectCurrent = async (state: SourceActionState): Promise<SourceActionState> => {
+  const { focusedIndex, items } = state
+  const item = items[focusedIndex]
+  if (!item) {
+    return state
+  }
+  return SelectItem.selectItem(state, item.name)
+}

--- a/packages/source-action-worker/test/FocusSourceAction.test.ts
+++ b/packages/source-action-worker/test/FocusSourceAction.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as FocusSourceAction from '../src/parts/FocusSourceAction/FocusSourceAction.ts'
+
+const state = {
+  ...createDefaultState(),
+  focusedIndex: 0,
+  items: [
+    { isFocused: true, name: 'First' },
+    { isFocused: false, name: 'Second' },
+  ],
+}
+
+test('focuses source actions by keyboard direction', () => {
+  expect(FocusSourceAction.focusNext(state).focusedIndex).toBe(1)
+  expect(FocusSourceAction.focusPrevious({ ...state, focusedIndex: 1 }).focusedIndex).toBe(0)
+  expect(FocusSourceAction.focusFirst({ ...state, focusedIndex: 1 }).focusedIndex).toBe(0)
+  expect(FocusSourceAction.focusLast(state).focusedIndex).toBe(1)
+})
+
+test('keeps focus within the action list', () => {
+  expect(FocusSourceAction.focusNext({ ...state, focusedIndex: 1 }).focusedIndex).toBe(1)
+  expect(FocusSourceAction.focusPrevious(state).focusedIndex).toBe(0)
+  expect(FocusSourceAction.focusPrevious({ ...state, focusedIndex: -1, items: [] }).focusedIndex).toBe(-1)
+})

--- a/packages/source-action-worker/test/GetEventListeners.test.ts
+++ b/packages/source-action-worker/test/GetEventListeners.test.ts
@@ -1,7 +1,10 @@
-import { test, expect } from '@jest/globals'
+import { expect, test } from '@jest/globals'
 import { getEventListeners } from '../src/parts/GetEventListeners/GetEventListeners.ts'
 
 test('getEventListeners', () => {
   const result = getEventListeners()
-  expect(result).toBeDefined()
+  expect(result[0]).toEqual({
+    name: 'handleSourceActionClick',
+    params: ['handleSourceActionClick', 'event.target.dataset.name'],
+  })
 })

--- a/packages/source-action-worker/test/GetKeyBindings.test.ts
+++ b/packages/source-action-worker/test/GetKeyBindings.test.ts
@@ -3,5 +3,10 @@ import * as GetKeyBindings from '../src/parts/GetKeyBindings/GetKeyBindings.ts'
 
 test('getKeyBindings returns correct key bindings', () => {
   const keyBindings = GetKeyBindings.getKeyBindings()
-  expect(keyBindings).toBeDefined()
+  expect(keyBindings).toContainEqual({
+    args: ['SourceActions', 'SourceActions.selectCurrent', 0, 8],
+    command: 'Editor.executeWidgetCommand',
+    key: 3,
+    when: 38,
+  })
 })

--- a/packages/source-action-worker/test/GetSourceActionListItemVirtualDom.test.ts
+++ b/packages/source-action-worker/test/GetSourceActionListItemVirtualDom.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import { getSourceActionListItemVirtualDom } from '../src/parts/GetSourceActionListItemVirtualDom/GetSourceActionListItemVirtualDom.ts'
+
+test('attaches the click listener and action name to the source action row', () => {
+  const result = getSourceActionListItemVirtualDom({
+    edits: [],
+    isFocused: true,
+    name: "Fix 'quotes' problem",
+  })
+
+  expect(result[0]).toMatchObject({
+    'data-name': "Fix 'quotes' problem",
+    onClick: 'handleSourceActionClick',
+    role: 'option',
+  })
+})

--- a/packages/source-action-worker/test/GetSourceActions.test.ts
+++ b/packages/source-action-worker/test/GetSourceActions.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@jest/globals'
+import { createMockRpc } from '@lvce-editor/rpc'
+import { set as setEditorWorker } from '../src/parts/EditorWorker/EditorWorker.ts'
+import { set as setExtensionManagementWorker } from '../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.ts'
+import { getEditorSourceActions } from '../src/parts/GetSourceActions/GetSourceActions.ts'
+
+test('merges provided code actions with unique contributed actions', async () => {
+  const contributedActions = [
+    { kind: 'source.organizeImports', name: 'Organize Imports' },
+    { kind: 'source.sortImports', name: 'Sort Imports' },
+  ]
+  const providedActions = [
+    { edits: [], kind: 'quickfix', name: "Fix 'quotes' problem" },
+    { kind: 'source.organizeImports', name: 'Organize Imports' },
+  ]
+  const editorRpc = createMockRpc({
+    commandMap: {
+      'Editor.getLanguageId': () => 'javascript',
+      'Editor.getOffsetAtCursor': () => 15,
+      'Editor.getSourceActions': () => contributedActions,
+      'Editor.getText': () => 'const value = "test"',
+      'Editor.getUri': () => 'file:///test.js',
+    },
+  })
+  const extensionManagementRpc = createMockRpc({
+    commandMap: {
+      'Extensions.executeCodeActionProviders': () => providedActions,
+    },
+  })
+  setEditorWorker(editorRpc)
+  setExtensionManagementWorker(extensionManagementRpc)
+
+  await expect(getEditorSourceActions(42)).resolves.toEqual([
+    { edits: [], kind: 'quickfix', name: "Fix 'quotes' problem" },
+    { kind: 'source.organizeImports', name: 'Organize Imports' },
+    { kind: 'source.sortImports', name: 'Sort Imports' },
+  ])
+  expect(extensionManagementRpc.invocations).toEqual([
+    [
+      'Extensions.executeCodeActionProviders',
+      {
+        documentId: 42,
+        languageId: 'javascript',
+        text: 'const value = "test"',
+        uri: 'file:///test.js',
+      },
+      15,
+    ],
+  ])
+})
+
+test('rejects invalid code action results', async () => {
+  setEditorWorker(
+    createMockRpc({
+      commandMap: {
+        'Editor.getLanguageId': () => 'javascript',
+        'Editor.getOffsetAtCursor': () => 0,
+        'Editor.getSourceActions': () => [],
+        'Editor.getText': () => '',
+        'Editor.getUri': () => 'file:///test.js',
+      },
+    }),
+  )
+  setExtensionManagementWorker(
+    createMockRpc({
+      commandMap: {
+        'Extensions.executeCodeActionProviders': () => 'invalid',
+      },
+    }),
+  )
+
+  await expect(getEditorSourceActions(42)).rejects.toThrow('Code actions must be an array')
+})

--- a/packages/source-action-worker/test/RenderFocusContext.test.ts
+++ b/packages/source-action-worker/test/RenderFocusContext.test.ts
@@ -9,5 +9,5 @@ test('renderFocusContext', () => {
 
   const result = renderFocusContext(oldState, newState)
 
-  expect(result).toEqual(['Viewlet.setFocusContext', WhenExpression.FocusEditorRename])
+  expect(result).toEqual(['Viewlet.setFocusContext', WhenExpression.FocusSourceActions])
 })

--- a/packages/source-action-worker/test/SelectCurrent.test.ts
+++ b/packages/source-action-worker/test/SelectCurrent.test.ts
@@ -1,0 +1,35 @@
+import { expect, jest, test } from '@jest/globals'
+import { createMockRpc } from '@lvce-editor/rpc'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { set as setEditorWorker } from '../src/parts/EditorWorker/EditorWorker.ts'
+import { selectCurrent } from '../src/parts/SelectCurrent/SelectCurrent.ts'
+
+test('applies the focused code action', async () => {
+  const edits = [{ endOffset: 20, inserted: "'test'", startOffset: 14 }]
+  const editorRpc = createMockRpc({
+    commandMap: {
+      'Editor.applyDocumentEdits': jest.fn(),
+      'Editor.closeWidget2': jest.fn(),
+    },
+  })
+  setEditorWorker(editorRpc)
+  const state = {
+    ...createDefaultState(),
+    editorUid: 42,
+    focusedIndex: 0,
+    items: [{ edits, isFocused: true, name: "Fix 'quotes' problem" }],
+  }
+
+  await expect(selectCurrent(state)).resolves.toBe(state)
+  expect(editorRpc.invocations[0]).toEqual(['Editor.applyDocumentEdits', 42, edits])
+})
+
+test('does nothing when no action is focused', async () => {
+  const state = {
+    ...createDefaultState(),
+    focusedIndex: -1,
+    items: [],
+  }
+
+  await expect(selectCurrent(state)).resolves.toBe(state)
+})


### PR DESCRIPTION
## Details

Request runtime code actions from matching extensions, merge them with contributed source actions, and make the source-action list keyboard- and mouse-interactive. This also corrects the source-action focus context and wheel routing.

## Tests

- `npm test` (40 suites, 72 tests; 2 suites / 6 tests skipped)
- `npm run type-check`
- `npm run lint`
- `npm run build`
- Local LVCE UI: mouse selection, Up/Down/Home/End/Escape/Enter routing