### PR TITLE
Refresh diagnostics after source actions

### DIFF
--- a/packages/source-action-worker/src/parts/ApplyEdit/ApplyEdit.ts
+++ b/packages/source-action-worker/src/parts/ApplyEdit/ApplyEdit.ts
@@ -4,4 +4,5 @@ import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 export const applyEdit = async (editorUid: number, changes: readonly Change[]): Promise<void> => {
   // @ts-ignore
   await EditorWorker.invoke('Editor.applyDocumentEdits', editorUid, changes)
+  await EditorWorker.invoke('Editor.updateDiagnostics', editorUid)
 }

--- a/packages/source-action-worker/test/SelectCurrent.test.ts
+++ b/packages/source-action-worker/test/SelectCurrent.test.ts
@@ -3,6 +3,8 @@ import { createMockRpc } from '@lvce-editor/rpc'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { set as setEditorWorker } from '../src/parts/EditorWorker/EditorWorker.ts'
 import { selectCurrent } from '../src/parts/SelectCurrent/SelectCurrent.ts'
+import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.ts'
+import * as WidgetId from '../src/parts/WidgetId/WidgetId.ts'
 
 test('applies the focused code action', async () => {
   const edits = [{ endOffset: 20, inserted: "'test'", startOffset: 14 }]
@@ -10,6 +12,7 @@ test('applies the focused code action', async () => {
     commandMap: {
       'Editor.applyDocumentEdits': jest.fn(),
       'Editor.closeWidget2': jest.fn(),
+      'Editor.updateDiagnostics': jest.fn(),
     },
   })
   setEditorWorker(editorRpc)
@@ -21,7 +24,11 @@ test('applies the focused code action', async () => {
   }
 
   await expect(selectCurrent(state)).resolves.toBe(state)
-  expect(editorRpc.invocations[0]).toEqual(['Editor.applyDocumentEdits', 42, edits])
+  expect(editorRpc.invocations).toEqual([
+    ['Editor.applyDocumentEdits', 42, edits],
+    ['Editor.updateDiagnostics', 42],
+    ['Editor.closeWidget2', 42, WidgetId.SourceAction, 'SourceActions', WhenExpression.FocusSourceActions],
+  ])
 })
 
 test('does nothing when no action is focused', async () => {

--- a/packages/source-action-worker/test/SelectItem.test.ts
+++ b/packages/source-action-worker/test/SelectItem.test.ts
@@ -12,6 +12,7 @@ test('selectItem applies edits from the selected code action', async () => {
     commandMap: {
       'Editor.applyDocumentEdits': () => undefined,
       'Editor.closeWidget2': () => undefined,
+      'Editor.updateDiagnostics': () => undefined,
     },
   })
   setEditorWorker(editorRpc)
@@ -46,6 +47,7 @@ test('selectItem applies edits from the selected code action', async () => {
   await expect(selectItem(state, "Change spelling to 'abort'")).resolves.toBe(state)
   expect(editorRpc.invocations).toEqual([
     ['Editor.applyDocumentEdits', 42, edits],
+    ['Editor.updateDiagnostics', 42],
     ['Editor.closeWidget2', 42, WidgetId.SourceAction, 'SourceActions', WhenExpression.FocusSourceActions],
   ])
 })
@@ -65,6 +67,7 @@ test('selectItem executes organize imports when the action has no edits', async 
       'Editor.getLanguageId': () => 'typescript',
       'Editor.getText': () => 'import { b, a } from "./module.js"',
       'Editor.getUri': () => 'file:///test.ts',
+      'Editor.updateDiagnostics': () => undefined,
     },
   })
   const extensionManagementRpc = createMockRpc({
@@ -102,6 +105,7 @@ test('selectItem executes organize imports when the action has no edits', async 
     ['Editor.getText', 42],
     ['Editor.getUri', 42],
     ['Editor.applyDocumentEdits', 42, edits],
+    ['Editor.updateDiagnostics', 42],
     ['Editor.closeWidget2', 42, WidgetId.SourceAction, 'SourceActions', WhenExpression.FocusSourceActions],
   ])
 })


### PR DESCRIPTION
Refresh editor diagnostics after applying source-action edits so resolved warnings disappear immediately.